### PR TITLE
Added single-turn QA paraphrasing scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN pip3 install --upgrade pip
 RUN git fetch && git checkout ${GENIENLP_VERSION} && pip3 install -e .
 
 # uncomment the models you want to use
-# RUN decanlp cache-embeddings --destdir /usr/local/share/decanlp/embeddings --embeddings bert-large-uncased-whole-word-masking
-# RUN decanlp cache-embeddings --destdir /usr/local/share/decanlp/embeddings --embeddings bert-large-uncased-whole-word-masking-finetuned-squad
+# RUN genienlp cache-embeddings --destdir /usr/local/share/genienlp/embeddings --embeddings bert-large-uncased-whole-word-masking
+# RUN genienlp cache-embeddings --destdir /usr/local/share/genienlp/embeddings --embeddings bert-large-uncased-whole-word-masking-finetuned-squad
 
 # uncomment it you need Apex (for mixed precision training)
 # RUN yum install -y \
@@ -40,7 +40,7 @@ RUN git checkout ${GENIE_VERSION}
 RUN yarn link thingtalk
 RUN yarn install
 
-COPY lib.sh generate-dataset-job.sh train-job.sh evaluate-job.sh paraphrase-job.sh ./
+COPY lib.sh generate-dataset-job.sh train-job.sh evaluate-job.sh paraphrase-job.sh train-paraphrase-job.sh ./
 
 # add user genie-toolkit
 RUN useradd -ms /bin/bash -r genie-toolkit

--- a/paraphrase-job.sh
+++ b/paraphrase-job.sh
@@ -3,7 +3,7 @@
 . /opt/genie-toolkit/lib.sh
 
 parse_args "$0" "owner dataset_owner project experiment \
-            input_dataset output_dataset filtering_model paraphrasing_model_full_path skip_generation" "$@"
+            input_dataset output_dataset filtering_model paraphrasing_model_full_path skip_generation is_dialogue" "$@"
 shift $n
 
 set -e
@@ -22,65 +22,166 @@ on_error () {
 }
 trap on_error ERR
 
+export paraphrasing_arguments=$@
+
+make_input_ready(){
+    if [ "$is_dialogue" = true ] ; then
+    # add previous agent utterance; this additional context helps the paraphraser
+    python3 /opt/genienlp/genienlp/data_manipulation_scripts/dialog_to_tsv.py \
+      input_dataset/user/train.tsv \
+      --dialog_file input_dataset/synthetic.txt \
+      output_dataset/with_context.tsv
+    else
+      : # nothing to be done
+    fi
+}
+
+run_paraphrase(){
+  echo $paraphrasing_arguments
+  # run paraphrase generation
+  if [ "$is_dialogue" = true ] ; then
+    genienlp run-paraphrase \
+      --model_name_or_path paraphraser/ \
+      --input_file output_dataset/with_context.tsv \
+      --output_file output_dataset/paraphrased.tsv \
+      --input_column 0 \
+      --prompt_column 1 \
+      --thingtalk_column 2 \
+      --gold_column 3 \
+      $paraphrasing_arguments
+  else
+    genienlp run-paraphrase \
+      --model_name_or_path paraphraser \
+      --input_file input_dataset/train.tsv \
+      --output_file output_dataset/paraphrased.tsv \
+      --input_column 1 \
+      --thingtalk_column 2 \
+      $paraphrasing_arguments
+  fi
+}
+
+
+join(){
+  # join the original file and the paraphrasing output
+  if [ "$is_dialogue" = true ] ; then
+    export num_new_queries=$((`wc -l output_dataset/paraphrased.tsv | cut -d " " -f1` / `wc -l input_dataset/user/train.tsv | cut -d " " -f1`))
+    python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+      input_dataset/user/train.tsv \
+      output_dataset/unfiltered.tsv \
+      --query_file output_dataset/paraphrased.tsv \
+      --num_new_queries ${num_new_queries} \
+      --transformation replace_queries \
+      --remove_duplicates \
+      --output_columns 0 1 2 3 \
+      --utterance_column 2 \
+      --thingtalk_column 3
+    else
+      export num_new_queries=$((`wc -l output_dataset/paraphrased.tsv | cut -d " " -f1` / `wc -l input_dataset/train.tsv | cut -d " " -f1`))
+      python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+        input_dataset/train.tsv \
+        output_dataset/unfiltered.tsv \
+        --query_file output_dataset/paraphrased.tsv \
+        --num_new_queries ${num_new_queries} \
+        --transformation replace_queries \
+        --remove_duplicates \
+        --remove_with_heuristics
+    fi
+}
+
+run_parser(){
+  # get parser output for paraphrased utterances
+  if [ "$is_dialogue" = true ] ; then
+    mkdir -p filtering_dataset/almond/user/
+    cp output_dataset/unfiltered.tsv filtering_dataset/almond/user/eval.tsv
+    genienlp predict \
+      --data ./filtering_dataset \
+      --path filtering_model \
+      --eval_dir ./eval_dir \
+      --evaluate valid \
+      --task almond_dialogue_nlu \
+      --overwrite \
+      --silent \
+      --main_metric_only \
+      --skip_cache \
+      --val_batch_size 600
+  else
+    mkdir -p filtering_dataset/almond/
+    cp output_dataset/unfiltered.tsv filtering_dataset/almond/eval.tsv
+    genienlp predict \
+      --data ./filtering_dataset \
+      --path filtering_model \
+      --eval_dir ./eval_dir \
+      --evaluate valid \
+      --task almond \
+      --overwrite \
+      --silent \
+      --main_metric_only \
+      --skip_cache \
+      --val_batch_size 2000
+  fi
+}
+
+filter(){
+  # remove paraphrases that do not preserve the meaning according to the parser
+  if [ "$is_dialogue" = true ] ; then
+    python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+      output_dataset/unfiltered.tsv \
+      output_dataset/filtered.tsv \
+      --thingtalk_gold_file eval_dir/valid/almond_dialogue_nlu.tsv \
+      --transformation remove_wrong_thingtalk \
+      --remove_duplicates \
+      --output_columns 0 1 2 3 \
+      --utterance_column 2 \
+      --thingtalk_column 3
+  else
+    python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+      output_dataset/unfiltered.tsv \
+      output_dataset/filtered.tsv \
+      --thingtalk_gold_file ./eval_dir/valid/almond.tsv \
+      --transformation remove_wrong_thingtalk \
+      --remove_duplicates
+  fi
+}
+
+append_to_original(){
+  # append paraphrases to the end of the original training file and remove duplicates
+  if [ "$is_dialogue" = true ] ; then
+    cp ./eval_dir/valid/almond_dialogue_nlu.results.json ./output_dataset/
+    cp output_dataset/user/train.tsv output_dataset/user/train2.tsv
+    cat output_dataset/filtered.tsv >> output_dataset/user/train2.tsv
+    python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+      output_dataset/user/train2.tsv \
+      output_dataset/user/train.tsv \
+      --remove_duplicates \
+      --utterance_column 2
+    rm output_dataset/user/train2.tsv
+  else
+    cp ./eval_dir/valid/almond.results.json ./output_dataset/
+    cp output_dataset/train.tsv output_dataset/train2.tsv
+    cat output_dataset/filtered.tsv >> output_dataset/train2.tsv
+    python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+      output_dataset/train2.tsv \
+      output_dataset/train.tsv \
+      --remove_duplicates
+    rm output_dataset/train2.tsv
+  fi
+}
+
+
 if [ "$skip_generation" = true ] ; then
   echo "Skipping generation. Will filter the existing generations."
   if ! test -f input_dataset/unfiltered.tsv ; then
     exit 1
   fi
 else
-  # run paraphrase generation script
-  genienlp run-paraphrase \
-    --model_name_or_path paraphraser \
-    --input_file input_dataset/train.tsv \
-    --input_column 1 \
-    --thingtalk_column 2 \
-    --output_file output_dataset/paraphrased.tsv \
-    "$@"
-
-  # join the original file and the paraphrasing output
-  export num_new_queries=$((`wc -l output_dataset/paraphrased.tsv | cut -d " " -f1` / `wc -l input_dataset/train.tsv | cut -d " " -f1`))
-  python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
-    input_dataset/train.tsv \
-    output_dataset/unfiltered.tsv \
-    --query_file output_dataset/paraphrased.tsv \
-    --num_new_queries ${num_new_queries} \
-    --transformation replace_queries \
-    --remove_duplicates \
-    --remove_with_heuristics
+  make_input_ready
+  run_paraphrase
+  join
 fi
 
-# get parser output for paraphrased utterances
-mkdir -p almond/
-cp output_dataset/unfiltered.tsv almond/eval.tsv
-genienlp predict \
-  --data ./ \
-  --path filtering_model \
-  --eval_dir ./eval_dir \
-  --evaluate valid \
-  --task almond \
-  --overwrite \
-  --silent \
-  --main_metric_only \
-  --skip_cache \
-  --val_batch_size 2000
-
-# remove paraphrases that do not preserve the meaning according to the parser
-python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
-  output_dataset/unfiltered.tsv \
-  output_dataset/filtered.tsv \
-  --thingtalk_gold_file ./eval_dir/valid/almond.tsv \
-  --transformation remove_wrong_thingtalk \
-  --remove_duplicates
-
-cp ./eval_dir/valid/almond.results.json ./output_dataset/
-# append paraphrases to the end of the original training file
-cat output_dataset/train.tsv > output_dataset/train2.tsv
-cat output_dataset/filtered.tsv >> output_dataset/train2.tsv
-python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
-  output_dataset/train2.tsv \
-  output_dataset/train.tsv \
-  --remove_duplicates
-rm output_dataset/train2.tsv
+run_parser
+filter
+append_to_original
 
 # upload the new dataset to S3
 aws s3 sync output_dataset s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${output_dataset}

--- a/paraphrase-job.sh
+++ b/paraphrase-job.sh
@@ -9,40 +9,40 @@ shift $n
 set -e
 set -x
 
-aws s3 sync s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${input_dataset} ${input_dataset}/
-aws s3 sync s3://almond-research/${owner}/models/${project}/${experiment}/${filtering_model} ${filtering_model}/
+aws s3 sync s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${input_dataset} input_dataset/
+aws s3 sync --exclude '*/dataset/*' --exclude '*/cache/*' --exclude 'iteration_*.pth' --exclude '*_optim.pth' s3://almond-research/${owner}/models/${project}/${experiment}/${filtering_model} filtering_model/
 aws s3 sync s3://almond-research/${paraphrasing_model_full_path} paraphraser/
 
-mkdir -p ${output_dataset}
-cp -r ${input_dataset}/* ${output_dataset}
+mkdir -p output_dataset
+cp -r input_dataset/* output_dataset
 
 on_error () {
   # on failure upload the outputs to S3
-  aws s3 sync ${output_dataset} s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${output_dataset}
+  aws s3 sync output_dataset s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${output_dataset}
 }
 trap on_error ERR
 
 if [ "$skip_generation" = true ] ; then
   echo "Skipping generation. Will filter the existing generations."
-  if ! test -f ${input_dataset}/unfiltered.tsv ; then
+  if ! test -f input_dataset/unfiltered.tsv ; then
     exit 1
   fi
 else
   # run paraphrase generation script
   genienlp run-paraphrase \
     --model_name_or_path paraphraser \
-    --input_file ${input_dataset}/train.tsv \
+    --input_file input_dataset/train.tsv \
     --input_column 1 \
     --thingtalk_column 2 \
-    --output_file ${output_dataset}/paraphrased.tsv \
+    --output_file output_dataset/paraphrased.tsv \
     "$@"
 
   # join the original file and the paraphrasing output
-  export num_new_queries=$((`wc -l ${output_dataset}/paraphrased.tsv | cut -d " " -f1` / `wc -l ${input_dataset}/train.tsv | cut -d " " -f1`))
+  export num_new_queries=$((`wc -l output_dataset/paraphrased.tsv | cut -d " " -f1` / `wc -l input_dataset/train.tsv | cut -d " " -f1`))
   python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
-    ${input_dataset}/train.tsv \
-    ${output_dataset}/unfiltered.tsv \
-    --query_file ${output_dataset}/paraphrased.tsv \
+    input_dataset/train.tsv \
+    output_dataset/unfiltered.tsv \
+    --query_file output_dataset/paraphrased.tsv \
     --num_new_queries ${num_new_queries} \
     --transformation replace_queries \
     --remove_duplicates \
@@ -51,37 +51,39 @@ fi
 
 # get parser output for paraphrased utterances
 mkdir -p almond/
-cp ${output_dataset}/unfiltered.tsv almond/eval.tsv
+cp output_dataset/unfiltered.tsv almond/eval.tsv
 genienlp predict \
   --data ./ \
-  --path ${filtering_model} \
+  --path filtering_model \
   --eval_dir ./eval_dir \
   --evaluate valid \
   --task almond \
   --overwrite \
   --silent \
   --main_metric_only \
+  --skip_cache \
   --val_batch_size 2000
 
 # remove paraphrases that do not preserve the meaning according to the parser
 python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
-  ${output_dataset}/unfiltered.tsv \
-  ${output_dataset}/filtered.tsv \
+  output_dataset/unfiltered.tsv \
+  output_dataset/filtered.tsv \
   --thingtalk_gold_file ./eval_dir/valid/almond.tsv \
   --transformation remove_wrong_thingtalk \
   --remove_duplicates
 
+cp ./eval_dir/valid/almond.results.json ./output_dataset/
 # append paraphrases to the end of the original training file
-cat ${output_dataset}/train.tsv > ${output_dataset}/train2.tsv
-cat ${output_dataset}/filtered.tsv >> ${output_dataset}/train2.tsv
+cat output_dataset/train.tsv > output_dataset/train2.tsv
+cat output_dataset/filtered.tsv >> output_dataset/train2.tsv
 python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
-  ${output_dataset}/train2.tsv \
-  ${output_dataset}/train.tsv \
+  output_dataset/train2.tsv \
+  output_dataset/train.tsv \
   --remove_duplicates
-rm ${output_dataset}/train2.tsv
+rm output_dataset/train2.tsv
 
 # upload the new dataset to S3
-aws s3 sync ${output_dataset} s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${output_dataset}
+aws s3 sync output_dataset s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${output_dataset}
 
 
 

--- a/paraphrase-job.sh
+++ b/paraphrase-job.sh
@@ -2,60 +2,86 @@
 
 . /opt/genie-toolkit/lib.sh
 
-parse_args "$0" "train_or_gen owner dataset_owner task_name experiment dataset model" "$@"
+parse_args "$0" "owner dataset_owner project experiment \
+            input_dataset output_dataset filtering_model paraphrasing_model_full_path skip_generation" "$@"
 shift $n
 
 set -e
 set -x
 
-aws s3 sync s3://almond-research/${dataset_owner}/dataset/${experiment}/${dataset} dataset/
+aws s3 sync s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${input_dataset} ${input_dataset}/
+aws s3 sync s3://almond-research/${owner}/models/${project}/${experiment}/${filtering_model} ${filtering_model}/
+aws s3 sync s3://almond-research/${paraphrasing_model_full_path} paraphraser/
 
-modeldir="$HOME/models/$model"
-mkdir -p "$modeldir"
-rm -fr "$modeldir/dataset"
-mkdir "$modeldir/dataset"
-rm -fr "$modeldir/cache"
-mkdir -p "$modeldir/cache"
-ln -s "$HOME/dataset" "$modeldir/dataset/${task_name}"
-ln -s $modeldir /home/genie-toolkit/current
-mkdir -p "/shared/tensorboard/${experiment}/${owner}/${model}"
+mkdir -p ${output_dataset}
+cp -r ${input_dataset}/* ${output_dataset}
 
+on_error () {
+  # on failure upload the outputs to S3
+  aws s3 sync ${output_dataset} s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${output_dataset}
+}
+trap on_error ERR
 
-if [ "$train_or_gen" = "train" ]
-then
-  # run paraphrase training script
-  genienlp train-paraphrase \
-    --train_data_file dataset/para_freeform_train.txt \
-    --eval_data_file dataset/para_freeform_dev.txt \
-    --output_dir "$modeldir" \
-    --tensorboard_dir "/shared/tensorboard/${experiment}/${owner}/${model}" \
-    --model_type gpt2 \
-    --do_train \
-    --do_eval \
-    --evaluate_during_training \
-    --overwrite_output_dir \
-    --logging_steps 1000 \
-    --save_steps 1000 \
-    --max_steps 40000 \
-    --save_total_limit 1 \
-    "$@"
-  aws s3 sync $modeldir/ s3://almond-research/${owner}/models/${experiment}/${model}
+if [ "$skip_generation" = true ] ; then
+  echo "Skipping generation. Will filter the existing generations."
+  if ! test -f ${input_dataset}/unfiltered.tsv ; then
+    exit 1
+  fi
 else
   # run paraphrase generation script
-  workingdir="$HOME/${workdir}"
-  mkdir -p ${workingdir}/eval_dir
-  aws s3 sync s3://almond-research/${owner}/models/${experiment}/${model} $modeldir/
   genienlp run-paraphrase \
-    --model_type gpt2 \
-    --model_name_or_path "$modeldir" \
-    --input_file dataset/test.tsv \
+    --model_name_or_path paraphraser \
+    --input_file ${input_dataset}/train.tsv \
     --input_column 1 \
-    --output_file ${workingdir}/eval_dir/output.tsv \
+    --thingtalk_column 2 \
+    --output_file ${output_dataset}/paraphrased.tsv \
     "$@"
-  aws s3 sync ${workingdir}/eval_dir s3://almond-research/${owner}/models/${experiment}/${model}/eval/
+
+  # join the original file and the paraphrasing output
+  export num_new_queries=$((`wc -l ${output_dataset}/paraphrased.tsv | cut -d " " -f1` / `wc -l ${input_dataset}/train.tsv | cut -d " " -f1`))
+  python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+    ${input_dataset}/train.tsv \
+    ${output_dataset}/unfiltered.tsv \
+    --query_file ${output_dataset}/paraphrased.tsv \
+    --num_new_queries ${num_new_queries} \
+    --transformation replace_queries \
+    --remove_duplicates \
+    --remove_with_heuristics
 fi
 
+# get parser output for paraphrased utterances
+mkdir -p almond/
+cp ${output_dataset}/unfiltered.tsv almond/eval.tsv
+genienlp predict \
+  --data ./ \
+  --path ${filtering_model} \
+  --eval_dir ./eval_dir \
+  --evaluate valid \
+  --task almond \
+  --overwrite \
+  --silent \
+  --main_metric_only \
+  --val_batch_size 2000
+
+# remove paraphrases that do not preserve the meaning according to the parser
+python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+  ${output_dataset}/unfiltered.tsv \
+  ${output_dataset}/filtered.tsv \
+  --thingtalk_gold_file ./eval_dir/valid/almond.tsv \
+  --transformation remove_wrong_thingtalk \
+  --remove_duplicates
+
+# append paraphrases to the end of the original training file
+cat ${output_dataset}/train.tsv > ${output_dataset}/train2.tsv
+cat ${output_dataset}/filtered.tsv >> ${output_dataset}/train2.tsv
+python3 /opt/genienlp/genienlp/data_manipulation_scripts/transform_dataset.py \
+  ${output_dataset}/train2.tsv \
+  ${output_dataset}/train.tsv \
+  --remove_duplicates
+rm ${output_dataset}/train2.tsv
+
+# upload the new dataset to S3
+aws s3 sync ${output_dataset} s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${output_dataset}
 
 
-rm -fr "$modeldir/cache"
-rm -fr "$modeldir/dataset"
+

--- a/paraphrase.sh
+++ b/paraphrase.sh
@@ -3,13 +3,16 @@
 . config
 . lib.sh
 
-parse_args "$0" "train_or_gen experiment dataset model" "$@"
+
+parse_args "$0" "skip_generation=false experiment input_dataset output_dataset filtering_model paraphrasing_model_full_path=None" "$@"
 shift $n
-check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE train_task_name"
+check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT TRAIN_TASK_NAME"
 
 
-JOB_NAME=${OWNER}-paraphrase-${experiment}-${model}
-cmdline="--train_or_gen ${train_or_gen} --owner ${OWNER} --dataset_owner ${DATASET_OWNER} --task_name ${train_task_name} --experiment $experiment --dataset $dataset --model $model -- "$(requote "$@")
+JOB_NAME=${OWNER}-paraphrase-${output_dataset}
+cmdline="--owner ${OWNER} --dataset_owner ${DATASET_OWNER} --project ${PROJECT} --experiment $experiment \
+         --input_dataset $input_dataset --output_dataset $output_dataset --filtering_model $filtering_model \
+         --paraphrasing_model_full_path $paraphrasing_model_full_path --skip_generation $skip_generation -- "$(requote "$@")
 
 set -e
 set -x

--- a/paraphrase.sh
+++ b/paraphrase.sh
@@ -6,7 +6,7 @@
 
 parse_args "$0" "skip_generation=false experiment input_dataset output_dataset filtering_model paraphrasing_model_full_path=None" "$@"
 shift $n
-check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT TRAIN_TASK_NAME"
+check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT"
 
 
 JOB_NAME=${OWNER}-paraphrase-${output_dataset}

--- a/paraphrase.sh
+++ b/paraphrase.sh
@@ -4,7 +4,8 @@
 . lib.sh
 
 
-parse_args "$0" "skip_generation=false experiment input_dataset output_dataset filtering_model paraphrasing_model_full_path=None" "$@"
+parse_args "$0" "skip_generation=false experiment input_dataset output_dataset filtering_model paraphrasing_model_full_path=None \
+            is_dialogue=false" "$@"
 shift $n
 check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT"
 
@@ -12,7 +13,8 @@ check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT"
 JOB_NAME=${OWNER}-paraphrase-${output_dataset}
 cmdline="--owner ${OWNER} --dataset_owner ${DATASET_OWNER} --project ${PROJECT} --experiment $experiment \
          --input_dataset $input_dataset --output_dataset $output_dataset --filtering_model $filtering_model \
-         --paraphrasing_model_full_path $paraphrasing_model_full_path --skip_generation $skip_generation -- "$(requote "$@")
+         --paraphrasing_model_full_path $paraphrasing_model_full_path --skip_generation $skip_generation \
+         --is_dialogue $is_dialogue -- "$(requote "$@")
 
 set -e
 set -x

--- a/paraphrase.sh
+++ b/paraphrase.sh
@@ -4,17 +4,16 @@
 . lib.sh
 
 
-parse_args "$0" "skip_generation=false experiment input_dataset output_dataset filtering_model paraphrasing_model_full_path=None \
-            is_dialogue=false" "$@"
+parse_args "$0" "skip_generation=false experiment input_dataset output_dataset filtering_model paraphrasing_model_full_path=None" "$@"
 shift $n
-check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT"
+check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT TRAIN_TASK_NAME"
 
 
 JOB_NAME=${OWNER}-paraphrase-${output_dataset}
 cmdline="--owner ${OWNER} --dataset_owner ${DATASET_OWNER} --project ${PROJECT} --experiment $experiment \
          --input_dataset $input_dataset --output_dataset $output_dataset --filtering_model $filtering_model \
          --paraphrasing_model_full_path $paraphrasing_model_full_path --skip_generation $skip_generation \
-         --is_dialogue $is_dialogue -- "$(requote "$@")
+         --task_name ${TRAIN_TASK_NAME} -- "$(requote "$@")
 
 set -e
 set -x

--- a/paraphrase.yaml.in
+++ b/paraphrase.yaml.in
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: genie-toolkit
     owner: @@OWNER@@
-    job-type: train
+    job-type: paraphrase
 
 spec:
   completions: 1
@@ -33,9 +33,6 @@ spec:
         image: @@IMAGE@@
         imagePullPolicy: Always
         command: ['/bin/sh', '-c', '/opt/genie-toolkit/paraphrase-job.sh @@cmdline@@']
-        volumeMounts:
-          - name: tensorboard
-            mountPath: /shared/tensorboard
         resources:
           limits:
             cpu: 32
@@ -43,10 +40,6 @@ spec:
             nvidia.com/gpu: 4
           requests:
             cpu: 16
-      volumes:
-      - name: tensorboard
-        persistentVolumeClaim:
-          claimName: tensorboard
       tolerations:
       - key: nvidia.com/gpu
         operator: Exists

--- a/train-paraphrase-job.sh
+++ b/train-paraphrase-job.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. /opt/genie-toolkit/lib.sh
+
+parse_args "$0" "owner dataset_owner task_name project experiment dataset model" "$@"
+shift $n
+
+set -e
+set -x
+
+aws s3 sync s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${dataset} dataset/
+
+modeldir="$HOME/$model"
+mkdir -p "$modeldir"
+mkdir -p "/shared/tensorboard/${project}/${experiment}/${owner}/${model}"
+
+# run paraphrase training script
+genienlp train-paraphrase \
+  --train_data_file dataset/train.tsv \
+  --eval_data_file dataset/dev.tsv \
+  --output_dir "$modeldir" \
+  --tensorboard_dir "/shared/tensorboard/${project}/${experiment}/${owner}/${model}" \
+  --do_train \
+  --do_eval \
+  --evaluate_during_training \
+  --overwrite_output_dir \
+  --logging_steps 200 \
+  --save_steps 200 \
+  --max_steps -1 \
+  --save_total_limit 1 \
+  "$@"
+
+aws s3 sync $modeldir/ s3://almond-research/${owner}/models/${project}/${experiment}/${model}
+
+
+

--- a/train-paraphrase-job.sh
+++ b/train-paraphrase-job.sh
@@ -2,7 +2,7 @@
 
 . /opt/genie-toolkit/lib.sh
 
-parse_args "$0" "owner dataset_owner task_name project experiment dataset model" "$@"
+parse_args "$0" "owner dataset_owner project experiment dataset model" "$@"
 shift $n
 
 set -e

--- a/train-paraphrase.sh
+++ b/train-paraphrase.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. config
+. lib.sh
+
+
+parse_args "$0" "experiment=paraphrase dataset model" "$@"
+shift $n
+check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT TRAIN_TASK_NAME"
+
+
+JOB_NAME=${OWNER}-paraphrase-${model}
+cmdline="--owner ${OWNER} --dataset_owner ${DATASET_OWNER} --task_name ${TRAIN_TASK_NAME} --project ${PROJECT} --experiment $experiment --dataset $dataset --model $model -- "$(requote "$@")
+
+set -e
+set -x
+replace_config paraphrase.yaml.in > paraphrase.yaml
+
+kubectl -n research delete job ${JOB_NAME} || true
+kubectl apply -f paraphrase.yaml

--- a/train-paraphrase.sh
+++ b/train-paraphrase.sh
@@ -6,11 +6,11 @@
 
 parse_args "$0" "experiment=paraphrase dataset model" "$@"
 shift $n
-check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT TRAIN_TASK_NAME"
+check_config "IAM_ROLE OWNER DATASET_OWNER IMAGE PROJECT"
 
 
 JOB_NAME=${OWNER}-paraphrase-${model}
-cmdline="--owner ${OWNER} --dataset_owner ${DATASET_OWNER} --task_name ${TRAIN_TASK_NAME} --project ${PROJECT} --experiment $experiment --dataset $dataset --model $model -- "$(requote "$@")
+cmdline="--owner ${OWNER} --dataset_owner ${DATASET_OWNER} --project ${PROJECT} --experiment $experiment --dataset $dataset --model $model -- "$(requote "$@")
 
 set -e
 set -x

--- a/train-paraphrase.yaml.in
+++ b/train-paraphrase.yaml.in
@@ -20,7 +20,7 @@ spec:
       labels:
         app: genie-toolkit
         owner: @@OWNER@@
-        job-type: paraphrase
+        job-type: train
       annotations:
         iam.amazonaws.com/role: @@IAM_ROLE@@
 

--- a/train-paraphrase.yaml.in
+++ b/train-paraphrase.yaml.in
@@ -26,23 +26,23 @@ spec:
 
     spec:
       nodeSelector:
-        beta.kubernetes.io/instance-type: p3.8xlarge
+        beta.kubernetes.io/instance-type: p3.2xlarge
       restartPolicy: Never
       containers:
       - name: main
         image: @@IMAGE@@
         imagePullPolicy: Always
-        command: ['/bin/sh', '-c', '/opt/genie-toolkit/paraphrase-job.sh @@cmdline@@']
+        command: ['/bin/sh', '-c', '/opt/genie-toolkit/train-paraphrase-job.sh @@cmdline@@']
         volumeMounts:
           - name: tensorboard
             mountPath: /shared/tensorboard
         resources:
           limits:
-            cpu: 32
-            memory: 220G
-            nvidia.com/gpu: 4
+            cpu: 8
+            memory: 55G
+            nvidia.com/gpu: 1
           requests:
-            cpu: 16
+            cpu: 4
       volumes:
       - name: tensorboard
         persistentVolumeClaim:


### PR DESCRIPTION
Training script for paraphrasing is separated from generation script. In the future, training script (train-paraphrase.sh) and its yaml file should be merged with `train.sh` and its yaml file.

`paraphrase.sh` generates paraphrases and filters them using a parser, or -in the second round of paraphrasing- uses the existing generations and just filters them.

Paraphrasing script by default uses 4-GPU machines. Generation is completely parallelized, and the utilization of all GPUs is >98% at all times, so this is cost-effective.
