### PR TITLE
Small changes to deal with disk space limits

### DIFF
--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -22,15 +22,7 @@ RUN git clone https://github.com/stanford-oval/genienlp /opt/genienlp && \
 	&& rm -fr /root/.cache
 
 # download word embeddings
-RUN mkdir -p /usr/local/share/genienlp/embeddings
-WORKDIR /usr/local/share/genienlp/embeddings
-#RUN curl -L https://oval.cs.stanford.edu/data/glove/embeddings.tar.xz | tar xJv
-RUN true 1 && genienlp cache-embeddings -d /usr/local/share/genienlp/embeddings --embeddings bert-base-multilingual-uncased
-RUN true 1 && genienlp cache-embeddings -d /usr/local/share/genienlp/embeddings --embeddings bert-base-uncased
-RUN true 1 && genienlp cache-embeddings -d /usr/local/share/genienlp/embeddings --embeddings bert-base-cased
-RUN true 1 && genienlp cache-embeddings -d /usr/local/share/genienlp/embeddings --embeddings xlm-roberta-base
-RUN true 1 && genienlp cache-embeddings -d /usr/local/share/genienlp/embeddings --embeddings bert-base-chinese
-RUN chmod 0755 /usr/local/share/genienlp/embeddings/[0-9a-f]*
+RUN mkdir -p /usr/local/share/genienlp/embeddings && chmod 0777 /usr/local/share/genienlp/embeddings
 ENV GENIENLP_EMBEDDINGS=/usr/local/share/genienlp/embeddings
 
 # install nodejs 10.x and yarn

--- a/generate-dataset-job.sh
+++ b/generate-dataset-job.sh
@@ -11,11 +11,11 @@ set -x
 mkdir workdir
 cd workdir
 
-on_error () {
-	# on failure ship everything to s3
-	aws s3 sync ./ s3://almond-research/${owner}/tmp/${project}/
-}
-trap on_error ERR
+#on_error () {
+#	# on failure ship everything to s3
+#	aws s3 sync ./ s3://almond-research/${owner}/tmp/${project}/
+#}
+#trap on_error ERR
 
 pwd
 aws s3 sync s3://almond-research/${owner}/workdir/${project}/ .

--- a/generate-dataset.yaml.in
+++ b/generate-dataset.yaml.in
@@ -37,7 +37,9 @@ spec:
           limits:
             cpu: 15.5
             memory: 55Gi
+            ephemeral-storage: 75G
           requests:
             cpu: 15.5
             memory: 55Gi
+            ephemeral-storage: 75G
       tolerations: []

--- a/train-job.sh
+++ b/train-job.sh
@@ -15,7 +15,7 @@ if ! test  ${load_from} = 'None' ; then
 	aws s3 sync ${load_from}/ "$modeldir"/ --exclude "iteration_*.pth" --exclude "*eval/*"  --exclude "*.log"
 fi
 
-aws s3 sync s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${dataset} dataset/
+aws s3 sync --exclude "synthetic*.txt" s3://almond-research/${dataset_owner}/dataset/${project}/${experiment}/${dataset} dataset/
 
 rm -fr "$modeldir/dataset"
 mkdir "$modeldir/dataset"

--- a/train.yaml.in
+++ b/train.yaml.in
@@ -38,11 +38,15 @@ spec:
             mountPath: /shared/tensorboard
         resources:
           limits:
-            cpu: 8
+            cpu: 7.5
             memory: 55G
             nvidia.com/gpu: 1
+            ephemeral-storage: 30G
           requests:
-            cpu: 4
+            cpu: 7.5
+            memory: 55G
+            nvidia.com/gpu: 1
+            ephemeral-storage: 30G
       volumes:
       - name: tensorboard
         persistentVolumeClaim:


### PR DESCRIPTION
In the last few rounds of dialogue datasets, I have managed to change the sampling enough that we no longer die of OOM, we die out of ENOSPC. _Progress_.

These changes ensure that we only die of ENOSPC (pod Evicted) when we actually have to, and it will try as hard as it can to reclaim other space before killing the job.