### PR TITLE
Add --eval_version for evaluate jobs

### DIFF
--- a/evaluate-job.sh
+++ b/evaluate-job.sh
@@ -23,8 +23,15 @@ ls -al
 mkdir -p tmp
 export GENIE_TOKENIZER_ADDRESS=tokenizer.default.svc.cluster.local:8888
 export TZ=America/Los_Angeles
-make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.results
+if [ "$eval_version" = "None" ] ; then
+	make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${model_owner}/${model}.{nlu,dialogue}.results
+	for f in $experiment/${eval_set}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
+		aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${model_owner}/
+else
+	echo "evaluation sets are versioned"
+	make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.results
+	for f in $experiment/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
+		aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${eval_version}/${model_owner}/
+fi
 
-for f in $experiment/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
-	aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${eval_version}/${model_owner}/
 done

--- a/evaluate-job.sh
+++ b/evaluate-job.sh
@@ -27,11 +27,13 @@ if [ "$eval_version" = "None" ] ; then
 	make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${model_owner}/${model}.{nlu,dialogue}.results
 	for f in $experiment/${eval_set}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
 		aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${model_owner}/
+	done
 else
 	echo "evaluation sets are versioned"
 	make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.results
 	for f in $experiment/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
 		aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${eval_version}/${model_owner}/
+	done
 fi
 
 done

--- a/evaluate-job.sh
+++ b/evaluate-job.sh
@@ -2,7 +2,7 @@
 
 . /opt/genie-toolkit/lib.sh
 
-parse_args "$0" "s3_bucket owner project experiment model model_owner eval_set" "$@"
+parse_args "$0" "s3_bucket owner project experiment model model_owner eval_set eval_version" "$@"
 shift $n
 
 set -e
@@ -23,8 +23,8 @@ ls -al
 mkdir -p tmp
 export GENIE_TOKENIZER_ADDRESS=tokenizer.default.svc.cluster.local:8888
 export TZ=America/Los_Angeles
-make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${model_owner}/${model}.{nlu,dialogue}.results
+make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.results
 
-for f in $experiment/${eval_set}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
-	aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${model_owner}/
+for f in $experiment/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
+	aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${eval_version}/${model_owner}/
 done

--- a/evaluate-job.sh
+++ b/evaluate-job.sh
@@ -35,5 +35,3 @@ else
 		aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${eval_version}/${model_owner}/
 	done
 fi
-
-done

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -3,7 +3,7 @@
 . config
 . lib.sh
 
-parse_args "$0" "experiment model model_owner eval_set=eval eval_version" "$@"
+parse_args "$0" "experiment model model_owner eval_set=eval eval_version=v2" "$@"
 shift $n
 check_config "S3_BUCKET OWNER IMAGE PROJECT"
 

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -3,7 +3,7 @@
 . config
 . lib.sh
 
-parse_args "$0" "experiment model model_owner eval_set=eval eval_version=v2" "$@"
+parse_args "$0" "experiment model model_owner eval_set=eval eval_version=None" "$@"
 shift $n
 check_config "S3_BUCKET OWNER IMAGE PROJECT"
 

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -3,12 +3,12 @@
 . config
 . lib.sh
 
-parse_args "$0" "experiment model model_owner eval_set=eval" "$@"
+parse_args "$0" "experiment model model_owner eval_set=eval eval_version" "$@"
 shift $n
 check_config "S3_BUCKET OWNER IMAGE PROJECT"
 
 JOB_NAME=${OWNER}-evaluate-${experiment}-${model_owner}-${model}
-cmdline="--s3_bucket ${S3_BUCKET} --owner ${OWNER} --project ${PROJECT} --experiment ${experiment} --model ${model} --model_owner ${model_owner} --eval_set ${eval_set} -- "$(requote "$@")
+cmdline="--s3_bucket ${S3_BUCKET} --owner ${OWNER} --project ${PROJECT} --experiment ${experiment} --model ${model} --model_owner ${model_owner} --eval_set ${eval_set} --eval_version ${eval_version} -- "$(requote "$@")
 
 set -e
 set -x


### PR DESCRIPTION
Corresponds to `genie-workdirs` PR 4: "Dataset versioning for dlgthingtalk". Allows `evaluate.sh` to be called with a flag for the version of the evaluation set. Currently `dlgthingtalk`'s multidomain experiment has two versions of eval sets corresponding to different conventions, and there may be more in the future. SGD will also likely require versioning as we expand state representation.

These changes should leave `evaluate.sh`'s behavior unchanged for any past & present experiments without versioning.