### PR TITLE
Wip/paraphrase

### DIFF
--- a/evaluate-job.sh
+++ b/evaluate-job.sh
@@ -10,7 +10,7 @@ set -x
 
 # on_error () {
  	# on failure ship everything to s3
-# 	aws s3 sync . s3://${s3_bucket}/models/${project}/${experiment}/${model}/failed_eval/
+# 	aws s3 sync . s3://${s3_bucket}/${owner}/models/${project}/${experiment}/${model}/failed_eval/
 # }
 # trap on_error ERR
 

--- a/evaluate-job.sh
+++ b/evaluate-job.sh
@@ -10,14 +10,14 @@ set -x
 
 # on_error () {
  	# on failure ship everything to s3
-# 	aws s3 sync . s3://almond-research/${owner}/models/${project}/${experiment}/${model}/failed_eval/
+# 	aws s3 sync . s3://${s3_bucket}/models/${project}/${experiment}/${model}/failed_eval/
 # }
 # trap on_error ERR
 
 pwd
 aws s3 sync s3://${s3_bucket}/${owner}/workdir/${project} .
-#mkdir -p ${experiment}/models
-#aws s3 sync --exclude 'iteration_*.pth' --exclude '*_optim.pth' s3://almond-research/${owner}/models/${project}/${experiment}/${model}/ ${experiment}/models/${model}/
+# mkdir -p ${experiment}/models
+# aws s3 sync --exclude 'iteration_*.pth' --exclude '*_optim.pth' s3://${s3_bucket}/${owner}/models/${project}/${experiment}/${model}/ ${experiment}/models/${model}/
 
 ls -al
 mkdir -p tmp

--- a/evaluate-job.sh
+++ b/evaluate-job.sh
@@ -30,7 +30,7 @@ if [ "$eval_version" = "None" ] ; then
 	done
 else
 	echo "evaluation sets are versioned"
-	make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} ${experiment}/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.results
+	make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} eval_version=${eval_version} ${experiment}/${eval_set}/${eval_version}/${model_owner}/${model}.dialogue.results
 	for f in $experiment/${eval_set}/${eval_version}/${model_owner}/${model}.{nlu,dialogue}.{results,debug} ; do
 		aws s3 cp $f s3://${s3_bucket}/${owner}/workdir/${project}/${experiment}/${eval_set}/${eval_version}/${model_owner}/
 	done

--- a/evaluate.sh
+++ b/evaluate.sh
@@ -3,9 +3,9 @@
 . config
 . lib.sh
 
-parse_args "$0" "experiment model model_owner eval_set=eval eval_version=None" "$@"
-shift $n
 check_config "S3_BUCKET OWNER IMAGE PROJECT"
+parse_args "$0" "experiment model model_owner=${OWNER} eval_set=eval eval_version=None" "$@"
+shift $n
 
 JOB_NAME=${OWNER}-evaluate-${experiment}-${model_owner}-${model}
 cmdline="--s3_bucket ${S3_BUCKET} --owner ${OWNER} --project ${PROJECT} --experiment ${experiment} --model ${model} --model_owner ${model_owner} --eval_set ${eval_set} --eval_version ${eval_version} -- "$(requote "$@")

--- a/paraphrase-job.sh
+++ b/paraphrase-job.sh
@@ -16,7 +16,7 @@ set -x
 
 aws s3 sync s3://${s3_bucket}/${dataset_owner}/dataset/${project}/${experiment}/${input_dataset} input_dataset/
 aws s3 sync --exclude '*/dataset/*' --exclude '*/cache/*' --exclude 'iteration_*.pth' --exclude '*_optim.pth' s3://${s3_bucket}/${owner}/models/${project}/${experiment}/${filtering_model} filtering_model/
-aws s3 sync s3://${s3_bucket}/${paraphrasing_model_full_path} paraphraser/
+aws s3 sync --exclude '*checkpoint*' s3://${s3_bucket}/${paraphrasing_model_full_path} paraphraser/
 
 mkdir -p output_dataset
 cp -r input_dataset/* output_dataset
@@ -127,6 +127,7 @@ run_parser(){
     --skip_cache \
     --val_batch_size ${filtering_batch_size}
   cp ./eval_dir/valid/${task_name}.results.json ${output_dir}/
+  # cp ./eval_dir/valid/${task_name}.tsv ${output_dir}/ # useful for debugging the paraphraser
 }
 
 filter(){

--- a/paraphrase.sh
+++ b/paraphrase.sh
@@ -4,7 +4,7 @@
 . lib.sh
 
 
-parse_args "$0" "skip_generation=false skip_filtering=false keep_original_duplicates=false ignore_context=false experiment input_dataset output_dataset filtering_model paraphrasing_model_full_path=None" "$@"
+parse_args "$0" "skip_generation=false skip_filtering=false keep_original_duplicates=false ignore_context=false experiment input_dataset output_dataset filtering_model=null paraphrasing_model_full_path=None" "$@"
 shift $n
 check_config "S3_BUCKET OWNER DATASET_OWNER IMAGE PROJECT TRAIN_TASK_NAME"
 

--- a/paraphrase.sh
+++ b/paraphrase.sh
@@ -4,7 +4,7 @@
 . lib.sh
 
 
-parse_args "$0" "skip_generation=false skip_filtering=false keep_original_duplicates=false ignore_context=false experiment input_dataset output_dataset filtering_model=null paraphrasing_model_full_path=None" "$@"
+parse_args "$0" "skip_generation=false skip_filtering=false keep_original_duplicates=false ignore_context=false experiment input_dataset output_dataset filtering_model=None paraphrasing_model_full_path=None" "$@"
 shift $n
 check_config "S3_BUCKET OWNER DATASET_OWNER IMAGE PROJECT TRAIN_TASK_NAME"
 


### PR DESCRIPTION
- Two minor changes to make the evaluation script work.
- Paraphrasing models' checkpoints do not need to be downloaded from S3.
- During paraphrasing, `--filtering_model` can be left empty, useful for when `--skip_filtering true` is used.