### PR TITLE
kubeflow: v2 e2e training pipeline

### DIFF
--- a/kubeflow/components/evaluate.yaml
+++ b/kubeflow/components/evaluate.yaml
@@ -8,7 +8,6 @@ inputs:
   - {name: model, description: '', default: ''}
   - {name: model_owner, description: '', default: ''}
   - {name: eval_set, description: '', default: ''}
-  - {name: eval_version, description: '', default: ''}
   - {name: s3_model_dir, description: '', default: ''}
   - {name: additional_args, description: '', default: ''}
 outputs:
@@ -25,7 +24,7 @@ implementation:
     - -c 
     - |
       . /opt/genie-toolkit/lib.sh
-      parse_args "$0" "image project experiment model model_owner eval_set eval_version s3_model_dir s3_metrics_output metrics_output" "$@"
+      parse_args "$0" "image project experiment model model_owner eval_set s3_model_dir s3_metrics_output metrics_output" "$@"
       shift $n
       s3_model_dir=`cat $s3_model_dir`
       cd $HOME
@@ -41,12 +40,20 @@ implementation:
 
       export TZ=America/Los_Angeles
 
-      make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} \
-        eval_version=${eval_version} model=${MODEL_DIR} s3_model_dir=${s3_model_dir} evaluate
-
-      make geniedir=/opt/genie-toolkit thingpedia_cli=thingpedia experiment=$experiment eval_set=${eval_set} \
-        eval_version=${eval_version} model=${MODEL_DIR} \
-        s3_metrics_output=${s3_metrics_output} metrics_output=${metrics_output} evaluate-output-artifacts
+      make \
+        geniedir=/opt/genie-toolkit \
+        "owner=${owner}" \
+        "genie_k8s_owner=${owner}" \
+        "genie_k8s_project=${project}" \
+        "s3_bucket=${s3_bucket}" \
+        thingpedia_cli=thingpedia \
+        "experiment=$experiment" \
+        "eval_set=${eval_set}" \
+        "model=${MODEL_DIR}" \
+        "s3_model_dir=${s3_model_dir}" \
+        "metrics_output=${metrics_output}" \
+        evaluate \
+        evaluate-output-artifacts
 
     args: [
       'cmd',
@@ -56,7 +63,6 @@ implementation:
       --model, {inputValue: model},
       --model_owner, {inputValue: model_owner},
       --eval_set, {inputValue: eval_set},
-      --eval_version, {inputValue: eval_version},
       --s3_model_dir, {inputPath: s3_model_dir},
       --s3_metrics_output, {outputPath: s3_metrics_output},
       --metrics_output, {outputPath: metrics_output},

--- a/kubeflow/components/generate-dataset.yaml
+++ b/kubeflow/components/generate-dataset.yaml
@@ -27,14 +27,21 @@ implementation:
 
       /opt/genie-toolkit/sync-repos.sh 
       MAKEDIR=`get_make_dir ${project}`
+      
+      cat >> workdir/config.mk <<EOF
+      developer_key = ${THINGPEDIA_DEVELOPER_KEY}
+      EOF
       cd workdir/${MAKEDIR}
 
       export TZ=America/Los_Angeles
       make "-j${parallel}" \
           geniedir=/opt/genie-toolkit \
+          "owner=${owner}" \
+          "genie_k8s_owner=${owner}" \
+          "genie_k8s_project=${project}" \
+          "s3_bucket=${s3_bucket}" \
           thingpedia_cli=thingpedia \
           "experiment=${experiment}" \
-          "owner=${owner}" \
           $@ \
           datadir
 

--- a/kubeflow/components/train.yaml
+++ b/kubeflow/components/train.yaml
@@ -9,7 +9,6 @@ inputs:
   - {name: task_name, description: '', default: '' }
   - {name: project, description: '', default: ''}
   - {name: experiment, description: '', default: ''}
-  - {name: dataset, description: '', default: ''}
   - {name: model, description: '', default: ''}
   - {name: load_from, description: '', default: ''}
   - {name: s3_datadir, description: '', default: ''}
@@ -26,7 +25,7 @@ implementation:
     - |
       . /opt/genie-toolkit/lib.sh
 
-      parse_args "$0" "image s3_bucket owner dataset_owner task_name project experiment dataset model load_from s3_datadir s3_model_dir" "$@"
+      parse_args "$0" "image s3_bucket owner dataset_owner task_name project experiment model load_from s3_datadir s3_model_dir" "$@"
       shift $n 
       cd $HOME
       s3_datadir=`cat $s3_datadir`
@@ -79,7 +78,6 @@ implementation:
       --task_name, {inputValue: task_name},
       --project, {inputValue: project},
       --experiment, {inputValue: experiment},
-      --dataset, {inputValue: dataset},
       --model, {inputValue: model},
       --load_from, {inputValue: load_from},
       --s3_datadir, {inputPath: s3_datadir},

--- a/kubeflow/sync-repos.sh
+++ b/kubeflow/sync-repos.sh
@@ -14,8 +14,12 @@ THINGTALK_HEAD=`git rev-parse HEAD`
 if [ -n "${THINGTALK_VERSION}" ] && [ "${THINGTALK_VERSION}" != "${THINGTALK_HEAD}" ]; then
   git fetch
   git checkout ${THINGTALK_VERSION}
-  yarn install
-  yarn link
+  if test -f yarn.lock ; then
+    yarn install
+    yarn link
+  else
+    npm install
+  fi
 fi
 
 cd  /opt/genie-toolkit/
@@ -23,9 +27,15 @@ GENIE_HEAD=`git rev-parse HEAD`
 if [ -n "${GENIE_VERSION}" ] && [ "${GENIE_VERSION}" != "${GENIE_HEAD}" ]; then
   git fetch
   git checkout ${GENIE_VERSION}
-  yarn link thingtalk
-  yarn install
-  yarn link
+  if test -f yarn.lock ; then
+    yarn link thingtalk
+    yarn install
+    yarn link
+  else
+    npm link ../thingtalk
+    npm install
+    npm link
+  fi
 fi
 
 cd $HOME
@@ -33,10 +43,13 @@ if [ -n "${WORKDIR_REPO}" ] && [ -n "${WORKDIR_VERSION}" ]; then
   git clone $WORKDIR_REPO workdir
   cd workdir
   git checkout ${WORKDIR_VERSION}
-   if [ -n "${WORKDIR_S3_CONFIG_DIR}" ]; then
-     aws s3 cp --recursive ${WORKDIR_S3_CONFIG_DIR} .
-   fi
-  yarn link thingtalk
-  yarn link genie-toolkit
-  yarn
+  if test -f yarn.lock ; then
+    yarn link thingtalk
+    yarn link genie-toolkit
+    yarn install
+  elif test -f package-lock.json ; then
+    npm link ../thingtalk
+    npm link ../genie-toolkit
+    npm install
+  fi
 fi

--- a/kubeflow/upload_pipeline.py
+++ b/kubeflow/upload_pipeline.py
@@ -1,0 +1,6 @@
+import generate_train_eval 
+from utils import upload_pipeline
+import sys
+
+resp = upload_pipeline(sys.argv[2], getattr(generate_train_eval, sys.argv[1]))
+print(resp)

--- a/kubeflow/utils.py
+++ b/kubeflow/utils.py
@@ -31,14 +31,14 @@ def upload_pipeline(name, pipeline):
     # use upload_pipeline_version if an existing pipeline is found
     pid = None
     for p in pipelines:
-      if p.name == name:
-        pid = p.id
-        break
+        if p.name == name:
+          pid = p.id
+          break
 
     if pid:
-      resp = client.pipeline_uploads.upload_pipeline_version(compiled_pipeline_path, name=version, pipelineid=pid)
+        resp = client.pipeline_uploads.upload_pipeline_version(compiled_pipeline_path, name=version, pipelineid=pid)
     else:
-      resp = client.pipeline_uploads.upload_pipeline(compiled_pipeline_path, name=name)
+        resp = client.pipeline_uploads.upload_pipeline(compiled_pipeline_path, name=name)
 
     os.remove(compiled_pipeline_path)
     return resp

--- a/kubeflow/utils.py
+++ b/kubeflow/utils.py
@@ -13,10 +13,10 @@ def disable_caching(op):
     return op
 
 def add_env(op, envs):
-  """Add a dict of environments to container"""
-  for k, v in envs.items():
-    op.container.add_env_variable(V1EnvVar(name=k, value=v))
-  return op
+    """Add a dict of environments to container"""
+    for k, v in envs.items():
+        op.container.add_env_variable(V1EnvVar(name=k, value=v))
+    return op
 
 def upload_pipeline(name, pipeline):
     """Upload pipeline to kubeflow"""


### PR DESCRIPTION
Remove the requirement to upload a config.mk to s3, as that is
only used for the Thingpedia developer key and we can hardcode that.

Ensure that all the owner, project, bucket, etc. options as
passed to make, and remove the defaults from the pipeline so
users are required to set them when creating a run.

Update sync-repos for future compatibility with npm instead of yarn.

Remove eval version from evaluation.