### PR TITLE
Wip/filtering

### DIFF
--- a/kubeflow/components/filter-paraphrase.yaml
+++ b/kubeflow/components/filter-paraphrase.yaml
@@ -13,7 +13,7 @@ inputs:
   - {name: filtering_model, description: '', default: ''}
   - {name: filtering_batch_size, description: '', default: ''}
   - {name: paraphrase_subfolder, description: '', default: ''}
-  - {name: filtering_additional_args, description: '', default: ''}
+  - {name: additional_args, description: '', default: ''}
 outputs:
   - {name: s3_output_datadir}
 implementation:

--- a/kubeflow/components/filter-paraphrase.yaml
+++ b/kubeflow/components/filter-paraphrase.yaml
@@ -13,7 +13,7 @@ inputs:
   - {name: filtering_model, description: '', default: ''}
   - {name: filtering_batch_size, description: '', default: ''}
   - {name: paraphrase_subfolder, description: '', default: ''}
-  - {name: additional_args, description: '', default: ''}
+  - {name: filtering_additional_args, description: '', default: ''}
 outputs:
   - {name: s3_output_datadir}
 implementation:
@@ -44,7 +44,7 @@ implementation:
       mkdir -p `dirname $s3_output_datadir`
       echo ${s3_output_dir} > $s3_output_datadir
 
-      paraphrasing_arguments="$@"
+      filtering_arguments="$@"
 
       case "$task_name" in
         "almond_dialogue_nlu" | "almond_dialogue_nlu_agent")
@@ -80,7 +80,8 @@ implementation:
           --silent \
           --main_metric_only \
           --skip_cache \
-          --val_batch_size ${filtering_batch_size}
+          --val_batch_size ${filtering_batch_size} \
+          $filtering_arguments
         cp ./eval_dir/valid/${task_name}.results.json ${output_dir}/
         # cp ./eval_dir/valid/${task_name}.tsv ${output_dir}/ # useful for debugging the paraphraser
       }

--- a/kubeflow/components/generate-paraphrase.yaml
+++ b/kubeflow/components/generate-paraphrase.yaml
@@ -81,11 +81,16 @@ implementation:
           fi
 
           if [ "$is_dialogue" = true ] ; then
-            # add previous agent utterance; this additional context helps the paraphraser
-            genienlp dialog-to-tsv \
-              ${input_dir}/train.tsv \
-              --dialog_file input_dataset/synthetic.txt \
-              ${output_dir}/with_context.tsv
+              if [ "$ignore_context" = true ] ; then
+                : # nothing to be done
+              else
+                # add previous agent utterance; this additional context helps the paraphraser
+                genienlp dialog-to-tsv \
+                  ${input_dir}/train.tsv \
+                  --dialog_file input_dataset/synthetic.txt \
+                  ${output_dir}/with_context.tsv
+              fi
+               
           else
             : # nothing to be done
           fi
@@ -99,11 +104,10 @@ implementation:
             genienlp run-paraphrase \
             --task paraphrase \
             --model_name_or_path paraphraser \
-            --input_file ${output_dir}/with_context.tsv \
+            --input_file ${input_dir}/train.tsv \
             --output_file ${output_dir}/paraphrased.tsv \
-            --input_column 3 \
-            --thingtalk_column 2 \
-            --gold_column 3 \
+            --input_column 2 \
+            --thingtalk_column 3 \
             $paraphrasing_arguments
           else
             genienlp run-paraphrase \
@@ -148,7 +152,7 @@ implementation:
 
       # Delete intermediate files that don't help debugging
       rm ${output_dir}/paraphrased.tsv
-      rm ${output_dir}/with_context.tsv
+      rm -f ${output_dir}/with_context.tsv
 
       # upload the new dataset to S3
       aws s3 sync --no-progress output_dataset/ "${s3_output_dir}"

--- a/kubeflow/generate_train_eval.py
+++ b/kubeflow/generate_train_eval.py
@@ -345,6 +345,7 @@ def paraphrase_fewshot_step(
     paraphrasing_model,
     paraphrase_subfolder,
     paraphrase_additional_args,
+    filtering_additional_args,
 ):
     if do_paraphrase:
         pretrain_op = train_step(image=image,
@@ -386,7 +387,7 @@ def paraphrase_fewshot_step(
                                         filtering_batch_size=filtering_batch_size,
                                         genienlp_version=genienlp_version,
                                         paraphrase_subfolder=paraphrase_subfolder,
-                                        additional_args=paraphrase_additional_args)
+                                        additional_args=filtering_additional_args)
         
         train_s3_datadir = paraphrase_filtering_op.outputs['s3_output_datadir']
     
@@ -457,6 +458,7 @@ def everything(
     paraphrasing_model=PARAPHRASING_MODEL,
     paraphrase_subfolder='user',
     paraphrase_additional_args='',
+    filtering_additional_args='',
     eval_set='dev',
     eval_additional_args=''):
 
@@ -499,6 +501,7 @@ def everything(
         paraphrasing_model=paraphrasing_model,
         paraphrase_subfolder=paraphrase_subfolder,
         paraphrase_additional_args=paraphrase_additional_args,
+        filtering_additional_args=filtering_additional_args,
     )
     
     eval_op = eval_step(image=image,
@@ -647,6 +650,7 @@ def generate_paraphrase_train_eval_pipeline(
     paraphrasing_model=PARAPHRASING_MODEL,
     paraphrase_subfolder='user',
     paraphrase_additional_args='',
+    filtering_additional_args='',
     eval_set='dev',
     eval_additional_args=''
 ):
@@ -678,6 +682,7 @@ def generate_paraphrase_train_eval_pipeline(
                paraphrasing_model=paraphrasing_model,
                paraphrase_subfolder=paraphrase_subfolder,
                paraphrase_additional_args=paraphrase_additional_args,
+               filtering_additional_args=filtering_additional_args,
                eval_set=eval_set,
                eval_additional_args=eval_additional_args)
 
@@ -766,6 +771,7 @@ def generate_paraphrase_train_fewshot_eval_pipeline(
     paraphrasing_model=PARAPHRASING_MODEL,
     paraphrase_subfolder='user',
     paraphrase_additional_args='',
+    filtering_additional_args='',
     eval_set='dev',
     eval_additional_args=''
 ):
@@ -798,6 +804,7 @@ def generate_paraphrase_train_fewshot_eval_pipeline(
                paraphrasing_model=paraphrasing_model,
                paraphrase_subfolder=paraphrase_subfolder,
                paraphrase_additional_args=paraphrase_additional_args,
+               filtering_additional_args=filtering_additional_args,
                eval_set=eval_set,
                eval_additional_args=eval_additional_args)
     
@@ -832,6 +839,7 @@ def paraphrase_train_fewshot_eval_pipeline(
     paraphrasing_model=PARAPHRASING_MODEL,
     paraphrase_subfolder='user',
     paraphrase_additional_args='',
+    filtering_additional_args='',
     eval_set='dev',
     eval_additional_args=''
 ):
@@ -863,6 +871,7 @@ def paraphrase_train_fewshot_eval_pipeline(
                paraphrasing_model=paraphrasing_model,
                paraphrase_subfolder=paraphrase_subfolder,
                paraphrase_additional_args=paraphrase_additional_args,
+               filtering_additional_args=filtering_additional_args,
                eval_set=eval_set,
                eval_additional_args=eval_additional_args)
 
@@ -897,6 +906,7 @@ def paraphrase_train_eval_pipeline(
     paraphrasing_model=PARAPHRASING_MODEL,
     paraphrase_subfolder='user',
     paraphrase_additional_args='',
+    filtering_additional_args='',
     eval_set='dev',
     eval_additional_args=''
 ):
@@ -927,6 +937,7 @@ def paraphrase_train_eval_pipeline(
                paraphrasing_model=paraphrasing_model,
                paraphrase_subfolder=paraphrase_subfolder,
                paraphrase_additional_args=paraphrase_additional_args,
+               filtering_additional_args=filtering_additional_args,
                eval_set=eval_set,
                eval_additional_args=eval_additional_args)
 
@@ -960,6 +971,7 @@ def selftrain_pipeline(
     keep_original_duplicates='false',
     paraphrasing_model=PARAPHRASING_MODEL,
     paraphrase_additional_args='',
+    filtering_additional_args='',
     auto_annotate_additional_args='',
     eval_set='dev',
     eval_additional_args=''
@@ -1004,6 +1016,7 @@ def selftrain_pipeline(
         paraphrasing_model=paraphrasing_model,
         paraphrase_subfolder='user',
         paraphrase_additional_args=paraphrase_additional_args,
+        filtering_additional_args=filtering_additional_args,
     )
     
     # autoparaphrase and few-shot finetune the agent model
@@ -1031,6 +1044,7 @@ def selftrain_pipeline(
         paraphrasing_model=paraphrasing_model,
         paraphrase_subfolder='agent',
         paraphrase_additional_args=paraphrase_additional_args,
+        filtering_additional_args=filtering_additional_args,
     )
     
     auto_annotate_op = auto_annotate_step(image=image,
@@ -1147,6 +1161,7 @@ def selftrain_nopara_pipeline(
         paraphrasing_model='',
         paraphrase_subfolder='user',
         paraphrase_additional_args='',
+        filtering_additional_args='',
     )
     
     # autoparaphrase and few-shot finetune the agent model
@@ -1174,6 +1189,7 @@ def selftrain_nopara_pipeline(
         paraphrasing_model='',
         paraphrase_subfolder='agent',
         paraphrase_additional_args='',
+        filtering_additional_args='',
     )
     
     auto_annotate_op = auto_annotate_step(image=image,


### PR DESCRIPTION
This PR makes two changes to the paraphrase generation and filtering process:
- Generation now ignores synthetic.txt if `--ignore_context` is `true`.
- Filtering now accepts additional arguments that will be directly passed to genienlp.