### PR TITLE
Add a prediction-only pipeline

### DIFF
--- a/components/predict.yaml
+++ b/components/predict.yaml
@@ -1,0 +1,69 @@
+name: Predict
+description: |
+  Predict
+inputs:
+  - {name: image, description: '', default: ''}
+  - {name: eval_set, description: '', default: ''}
+  - {name: task_name, description: '', default: ''}
+  - {name: s3_model_dir, description: '', default: ''}
+  - {name: s3_input_datadir, description: '', default: ''}
+  - {name: dataset_subfolder, description: '', default: ''}
+  - {name: val_batch_size, description: '', default: ''}
+  - {name: additional_args, description: '', default: ''}
+outputs:
+  - {name: s3_output_datadir}
+implementation:
+  container:
+    image: '{{inputs.parameters.image}}'
+    command:
+    - /bin/bash
+    - -ex
+    - -c 
+    - |
+      . /opt/genie-toolkit/lib.sh
+      parse_args "$0" "image eval_set task_name s3_model_dir s3_input_datadir dataset_subfolder s3_output_datadir val_batch_size" "$@"
+      shift $n
+      cd $HOME
+
+      /opt/genie-toolkit/sync-repos.sh
+      
+      modeldir="$HOME/model/"
+      mkdir -p "$modeldir"
+
+      if test "${dataset_subfolder}" = "None" ; then
+        dataset_subfolder=
+      fi
+
+      aws s3 sync --no-progress "${s3_model_dir}" "$modeldir"/ --exclude "iteration_*.pth" --exclude "*_optim.pth" --exclude "*eval/*"  --exclude "*.log"
+      aws s3 sync --no-progress --exclude "synthetic*.txt" --exclude "*bootleg*" ${s3_input_datadir}${dataset_subfolder} dataset/almond
+
+      genienlp predict \
+          --data "dataset" \
+          --path "$modeldir" \
+          --eval_dir "./eval" \
+          --evaluate "$eval_set" \
+          --task ${task_name} \
+          --overwrite \
+          --silent \
+          --skip_cache \
+          --val_batch_size ${val_batch_size} \
+          $@
+
+      S3_OUTPUT_DATADIR=${s3_model_dir%/}/eval/`date +%s`
+      aws s3 sync --no-progress "./eval" ${S3_OUTPUT_DATADIR}
+
+      mkdir -p `dirname $s3_output_datadir`
+      echo ${S3_OUTPUT_DATADIR} > $s3_output_datadir
+
+    args: [
+      'cmd',
+      --image, {inputValue: image},
+      --eval_set, {inputValue: eval_set},
+      --task_name, {inputValue: task_name},
+      --s3_model_dir, {inputValue: s3_model_dir},
+      --s3_input_datadir, {inputValue: s3_input_datadir},
+      --dataset_subfolder, {inputValue: dataset_subfolder},
+      --s3_output_datadir, {outputPath: s3_output_datadir},
+      --val_batch_size, {inputValue: val_batch_size},
+      --, {inputValue: additional_args}
+    ]

--- a/pipelines/training.py
+++ b/pipelines/training.py
@@ -280,6 +280,48 @@ def eval_step(
 
     return eval_op
 
+def prediction_step(
+    image,
+    eval_set,
+    task_name,
+    s3_model_dir,
+    s3_input_datadir,
+    dataset_subfolder,
+    val_batch_size,
+    genienlp_version,
+    additional_args
+):
+
+    predict_env = {
+        'GENIENLP_VERSION': genienlp_version,
+    }
+
+    predict_num_gpus=4
+    predict_op = components.load_component_from_file('components/predict.yaml')(
+            image=image,
+            eval_set=eval_set,
+            task_name=task_name,
+            s3_model_dir=s3_model_dir,
+            s3_input_datadir=s3_input_datadir,
+            dataset_subfolder=dataset_subfolder,
+            val_batch_size=val_batch_size,
+            additional_args=additional_args)
+    (predict_op.container
+        .set_memory_request('150G')
+        .set_memory_limit('150G')
+        .set_cpu_request('16')
+        .set_cpu_limit('16')
+        # not supported yet in the version of kfp we're using
+        #.set_ephemeral_storage_request('75G')
+        #.set_ephemeral_storage_limit('75G')
+        .set_gpu_limit(str(predict_num_gpus))
+    )
+    (add_env(add_ssh_volume(predict_op), predict_env)
+        .add_toleration(V1Toleration(key='nvidia.com/gpu', operator='Exists', effect='NoSchedule'))
+        .add_node_selector_constraint('beta.kubernetes.io/instance-type', 'g4dn.12xlarge'))
+
+    return predict_op
+
 
 def paraphrase_fewshot_step(
     do_paraphrase,
@@ -1149,6 +1191,35 @@ def eval_only_pipeline(
         thingpedia_developer_key=thingpedia_developer_key,
         eval_set=eval_set,
         additional_args=additional_args)
+
+
+@dsl.pipeline(
+    name='Predict',
+    description='Run genienlp predict on a previously trained model'
+)
+def predict_pipeline(
+    image=default_image,
+    eval_set='',
+    task_name='',
+    s3_model_dir='',
+    s3_input_datadir='',
+    dataset_subfolder='None',
+    val_batch_size='4000',
+    additional_args='',
+    genienlp_version=GENIENLP_VERSION
+):
+    prediction_step(
+        image=image,
+        eval_set=eval_set,
+        task_name=task_name,
+        s3_model_dir=s3_model_dir,
+        s3_input_datadir=s3_input_datadir,
+        dataset_subfolder=dataset_subfolder,
+        val_batch_size=val_batch_size,
+        additional_args=additional_args,
+        genienlp_version=genienlp_version
+        )
+
 
 @dsl.pipeline(
     name='Paraphrase (and filter) a dataset',

--- a/upload_all_pipelines.sh
+++ b/upload_all_pipelines.sh
@@ -17,6 +17,7 @@ python3 upload_pipeline.py selftrain_pipeline selftrain
 python3 upload_pipeline.py selftrain_nopara_pipeline selftrain-nopara
 python3 upload_pipeline.py paraphrase_train_eval_pipeline paraphrase-train-eval
 python3 upload_pipeline.py paraphrase_only_pipeline paraphrase-only
+python3 upload_pipeline.py predict_pipeline predict
 
 
 # export CONTAINER_IMAGE=932360549041.dkr.ecr.us-west-2.amazonaws.com/masp:0.1


### PR DESCRIPTION
A pipeline that simply runs `genienlp predict` on a multi-GPU machine. This is useful for exploratory experiments.