### PR TITLE
train.yaml: sync database files from eval subfolder

### DIFF
--- a/components/train.yaml
+++ b/components/train.yaml
@@ -56,12 +56,7 @@ implementation:
       mkdir -p "$modeldir"
 
       if test "${s3_database_dir}" != None ; then
-        if test "${bootleg_model}" == "bootleg_wiki" ; then
-          # copy all embedding files for full models (eval folder contains those)
-          aws s3 sync --no-progress ${s3_database_dir}/eval/ ./database/
-        else
-          aws s3 sync --no-progress ${s3_database_dir}/train/ ./database/
-        fi
+        aws s3 sync --no-progress ${s3_database_dir}/eval/ ./database/
       fi
 
       if test "${s3_bootleg_prepped_data}" != None ; then


### PR DESCRIPTION
Since we feed OOD data during calibration, these database files are required for bootleg annotator.